### PR TITLE
Prevent callback function being called twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tiny module wrapping try/catch in JavaScript. 
 
-It's *literally 8 lines of code*, [just read it](tryit.js) that's all the documentation you'll need.
+It's *literally 11 lines of code*, [just read it](tryit.js) that's all the documentation you'll need.
 
 
 ## install

--- a/tryit.js
+++ b/tryit.js
@@ -2,10 +2,13 @@
 // Simple, re-usuable try-catch, this is a performance optimization
 // and provides a cleaner API.
 module.exports = function (fn, cb) {
+    var err;
+
     try {
         fn();
-        if (cb) cb(null);
     } catch (e) {
-        if (cb) cb(e);
+        err = e;
     }
+
+    if (cb) cb(err || null);
 };


### PR DESCRIPTION
## Why

Because there is a possibility that tryit runs callback function **twice**.
## Example

``` js
var tryit = require('tryit');

var count = 0;

function noop() {
  // doesn't throw
}

tryit(noop, function(e) {
  count++;
  throw new Error('called ' + count + ' time(s).');
});
```

As you can see, the callback function _always_ throws an error.

You may expect that the thrown error will be:

```
Error: called 1 time(s).
```

But, the actual error is:

```
Error: called 2 time(s).
```

When the first function doesn't throw any errors but the callback function throws an error, unfortunately it runs the callback function again.

This PR fixes this incorrect behavior.
